### PR TITLE
Add github actions to project, switch to debian base image

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,0 +1,18 @@
+name: GitHub Actions Demo
+run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+on: [push]
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -5,6 +5,11 @@ jobs:
   Build-Validation:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: List files in the repository
+        run: |
+          ls -l ${{ github.workspace }}
       - name: Select 'all' target
         run: sed -i "s/checksum/all/g" ${{ github.workspace }}/resources/options
       # - name: Docker Setup Docker
@@ -26,14 +31,4 @@ jobs:
             cd /
             ./xtide_build.sh
   
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out repository code
-        uses: actions/checkout@v4
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          ls -l ${{ github.workspace }}/src
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Build and push Docker images
         uses: docker/build-push-action@v6.11.0
         with:
+          context: ${{ github.workspace }}
           push: false
           tags: xtide-builder:latest
       - run: mkdir -p ${{ github.workspace }}/src
@@ -29,6 +30,8 @@ jobs:
             ./xtide_build.sh
       - name: List files in the repository
         run: |
-          ls -l ${{ github.workspace }}/src
+          md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin
+          md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS_Configurator_v2/Build/*.com
+          
   
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,10 +1,6 @@
 name: Build Validation
-run-name: ${{ github.actor }} pushed an update
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+run-name: Validation run ${{ github.run_number }} by @${{ github.actor }}
+on: [workflow_dispatch]
 
 jobs:
   Build-Validation:

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -35,20 +35,20 @@ jobs:
           RELEASE=$(cat ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Inc/Revision.inc | xargs)
           echo "Compare output with official binaries @ r$RELEASE."
           EXITCODE=0
-          echo "Filename\tActual\tExpected"
+          echo "Filename Actual Expected"
           for i in ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin; do
             BINNAME=$(basename $i)
-            wget https://www.xtideuniversalbios.org/binaries/r$RELEASE/$BINNAME
+            wget -q https://www.xtideuniversalbios.org/binaries/r$RELEASE/$BINNAME
             EXPECTED=$(tail -c +64 $BINNAME | md5sum | cut -d ' ' -f 1)
             ACTUAL=$(tail -c +64 $i | md5sum | cut -d ' ' -f 1)
             if [ $EXPECTED == $ACTUAL ]; then
-              echo "$i\t$ACTUAL\t$EXPECTED :white_check_mark:"
+              echo "$BINNAME $ACTUAL $EXPECTED ✅"
             else
-              echo "$i\t$ACTUAL\t$EXPECTED :x:"
+              echo "$BINNAME $ACTUAL $EXPECTED ❌"
               EXITCODE=1
             fi
           done
-          exit $SUCCESS
+          exit $EXITCODE
         shell: bash
           
   

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           RELEASE=$(cat ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Inc/Revision.inc | xargs)
           echo "Compare output with official binaries @ r$RELEASE."
-          for i in ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin
-            echo $i
+          for i in ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin; do
+            echo "$i"
           done
           # md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin
           # md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS_Configurator_v2/Build/*.com

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -28,10 +28,16 @@ jobs:
             cat /options
             cd /
             ./xtide_build.sh
-      - name: List files in the repository
+      - name: Verify output
         run: |
-          md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin
-          md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS_Configurator_v2/Build/*.com
+          RELEASE=$(cat ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Inc/Revision.inc | xargs)
+          echo "Compare output with official binaries @ r$RELEASE."
+          for i in ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin
+            echo $i
+          done
+          # md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin
+          # md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS_Configurator_v2/Build/*.com
+        shell: bash
           
   
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,10 +1,29 @@
-name: GitHub Actions Demo
-run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+name: Build Validation
+run-name: ${{ github.actor }} pushed an update
 on: [push]
 jobs:
-  Explore-GitHub-Actions:
+  Build-Validation:
     runs-on: ubuntu-latest
     steps:
+      - name: Docker Setup Docker
+        uses: docker/setup-docker-action@v4.1.0
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v6.11.0
+        with:
+          push: false
+          tags: xtide-builder
+      - run: mkdir -p ${{ github.workspace }}/src
+      - uses: addnab/docker-run-action@v3
+        with:
+          # username: ${{ secrets.DOCKER_USERNAME }}
+          # password: ${{ secrets.DOCKER_PASSWORD }}
+          # registry: gcr.io
+          image: xtide-builder
+          options: -v ${{ github.workspace }}/src:/src
+          # run: |
+          #   echo "Running Script"
+          #   /work/run-script
+  
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
       - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -33,7 +33,8 @@ jobs:
           RELEASE=$(cat ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Inc/Revision.inc | xargs)
           echo "Compare output with official binaries @ r$RELEASE."
           for i in ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin; do
-            echo "$i"
+            IBASE=$(basename $i)
+            echo "$i -> $IBASE"
           done
           # md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin
           # md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS_Configurator_v2/Build/*.com

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,6 +1,9 @@
 name: Build Validation
 run-name: Validation run ${{ github.run_number }} by @${{ github.actor }}
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   Build-Validation:

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -30,14 +30,24 @@ jobs:
             ./xtide_build.sh
       - name: Verify output
         run: |
+          mkdir -p ${{ github.workspace }}/compare
+          cd ${{ github.workspace }}/compare
           RELEASE=$(cat ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Inc/Revision.inc | xargs)
           echo "Compare output with official binaries @ r$RELEASE."
+          EXITCODE=0
+          echo "Filename\tActual\tExpected"
           for i in ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin; do
-            IBASE=$(basename $i)
-            echo "$i -> $IBASE"
+            BINNAME=$(basename $i)
+            wget https://www.xtideuniversalbios.org/binaries/r$RELEASE/$BINNAME
+            EXPECTED=$(tail -c +64 $BINNAME | md5sum | cut -d ' ' -f 1)
+            ACTUAL=$(tail -c +64 $i | md5sum | cut -d ' ' -f 1)
+            if [ $EXPECTED == $ACTUAL ]; then
+              echo "$i\t$ACTUAL\t$EXPECTED :white_check_mark:"
+            else
+              echo "$i\t$ACTUAL\t$EXPECTED :x:"
+              EXITCODE=1
           done
-          # md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin
-          # md5sum ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS_Configurator_v2/Build/*.com
+          exit $SUCCESS
         shell: bash
           
   

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -5,8 +5,8 @@ jobs:
   Build-Validation:
     runs-on: ubuntu-latest
     steps:
-      # - name: Check out repository code
-      #   uses: actions/checkout@v4
+      - name: Check out repository code
+        uses: actions/checkout@v4
       - name: Select 'all' target
         run: sed -i "s/checksum/all/g" ${{ runner.workspace }}/resources/options
       # - name: Docker Setup Docker

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -46,6 +46,7 @@ jobs:
             else
               echo "$i\t$ACTUAL\t$EXPECTED :x:"
               EXITCODE=1
+            fi
           done
           exit $SUCCESS
         shell: bash

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -44,7 +44,7 @@ jobs:
             ACTUALHASH=$(tail -c +64 $i | md5sum | cut -d ' ' -f 1)
             ACTUALSIZE=$(stat -c%s $i)
             echo -n "$BINNAME $ACTUALSIZE $EXPECTEDSIZE $ACTUALHASH $EXPECTEDHASH"
-            if [ $EXPECTEDSIZE == $ACTUALSIZE && $EXPECTEDHASH == $ACTUALHASH ]; then
+            if [[ $EXPECTEDSIZE == $ACTUALSIZE && $EXPECTEDHASH == $ACTUALHASH ]]; then
               echo "✅"
             else
               echo "❌"

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -19,7 +19,7 @@ jobs:
           # password: ${{ secrets.DOCKER_PASSWORD }}
           # registry: gcr.io
           image: xtide-builder:latest
-          options: --user $(id --user):$(id --group) -v ${{ github.workspace }}/src:/src
+          options: --user 1001:121 -v ${{ github.workspace }}/src:/src
           run: |
             cd /
             ./xtide_build.sh

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -19,7 +19,7 @@ jobs:
           # password: ${{ secrets.DOCKER_PASSWORD }}
           # registry: gcr.io
           image: xtide-builder:latest
-          options: -v ${{ github.workspace }}/src:/src
+          options: --user $(id -u):$(id -g) -v ${{ github.workspace }}/src:/src
           run: |
             cd /
             ./xtide_build.sh

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -5,8 +5,8 @@ jobs:
   Build-Validation:
     runs-on: ubuntu-latest
     steps:
-      - name: Docker Setup Docker
-        uses: docker/setup-docker-action@v4.1.0
+      # - name: Docker Setup Docker
+      #   uses: docker/setup-docker-action@v4.1.0
       - name: Build and push Docker images
         uses: docker/build-push-action@v6.11.0
         with:

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - actions-testing
 jobs:
   Build-Validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -5,6 +5,8 @@ jobs:
   Build-Validation:
     runs-on: ubuntu-latest
     steps:
+      - name: Select 'all' target
+        run: sed -i "s/checksum/all/g" ${{ github.workspace }}/resources/options
       # - name: Docker Setup Docker
       #   uses: docker/setup-docker-action@v4.1.0
       - name: Build and push Docker images
@@ -33,5 +35,5 @@ jobs:
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
       - name: List files in the repository
         run: |
-          ls ${{ github.workspace }}
+          ls -l ${{ github.workspace }}/src
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -5,13 +5,10 @@ jobs:
   Build-Validation:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-      - name: List files in the repository
-        run: |
-          ls -l ${{ github.workspace }}
+      # - name: Check out repository code
+      #   uses: actions/checkout@v4
       - name: Select 'all' target
-        run: sed -i "s/checksum/all/g" ${{ github.workspace }}/resources/options
+        run: sed -i "s/checksum/all/g" ${{ runner.workspace }}/resources/options
       # - name: Docker Setup Docker
       #   uses: docker/setup-docker-action@v4.1.0
       - name: Build and push Docker images
@@ -19,16 +16,19 @@ jobs:
         with:
           push: false
           tags: xtide-builder:latest
-      - run: mkdir -p ${{ github.workspace }}/src
+      - run: mkdir -p ${{ runner.workspace }}/src
       - uses: addnab/docker-run-action@v3
         with:
           # username: ${{ secrets.DOCKER_USERNAME }}
           # password: ${{ secrets.DOCKER_PASSWORD }}
           # registry: gcr.io
           image: xtide-builder:latest
-          options: --user 1001:121 -v ${{ github.workspace }}/src:/src
+          options: --user 1001:121 -v ${{ runner.workspace }}/src:/src
           run: |
             cd /
             ./xtide_build.sh
+      - name: List files in the repository
+        run: |
+          ls -l ${{ runner.workspace }}/src
   
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,6 +1,10 @@
 name: Build Validation
 run-name: ${{ github.actor }} pushed an update
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - actions-testing
 jobs:
   Build-Validation:
     runs-on: ubuntu-latest
@@ -18,9 +22,6 @@ jobs:
       - run: mkdir -p ${{ github.workspace }}/src
       - uses: addnab/docker-run-action@v3
         with:
-          # username: ${{ secrets.DOCKER_USERNAME }}
-          # password: ${{ secrets.DOCKER_PASSWORD }}
-          # registry: gcr.io
           image: xtide-builder:latest
           options: --user 1001:121 -v ${{ github.workspace }}/src:/src
           run: |
@@ -35,7 +36,7 @@ jobs:
           RELEASE=$(cat ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Inc/Revision.inc | xargs)
           echo "Compare output with official binaries @ r$RELEASE."
           EXITCODE=0
-          echo "Filename Size Actual Expected Hash Actual Expected"
+          echo "Filename - Size: Actual Expected - Hash: Actual Expected"
           for i in ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin; do
             BINNAME=$(basename $i)
             wget -q https://www.xtideuniversalbios.org/binaries/r$RELEASE/$BINNAME
@@ -43,7 +44,7 @@ jobs:
             EXPECTEDSIZE=$(stat -c%s $BINNAME)
             ACTUALHASH=$(tail -c +64 $i | md5sum | cut -d ' ' -f 1)
             ACTUALSIZE=$(stat -c%s $i)
-            echo -n "$BINNAME $ACTUALSIZE $EXPECTEDSIZE $ACTUALHASH $EXPECTEDHASH"
+            echo -n "$BINNAME - $ACTUALSIZE $EXPECTEDSIZE - $ACTUALHASH $EXPECTEDHASH "
             if [[ $EXPECTEDSIZE == $ACTUALSIZE && $EXPECTEDHASH == $ACTUALHASH ]]; then
               echo "✅"
             else

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -35,16 +35,19 @@ jobs:
           RELEASE=$(cat ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Inc/Revision.inc | xargs)
           echo "Compare output with official binaries @ r$RELEASE."
           EXITCODE=0
-          echo "Filename Actual Expected"
+          echo "Filename Size Actual Expected Hash Actual Expected"
           for i in ${{ github.workspace }}/src/trunk/XTIDE_Universal_BIOS/Build/*.bin; do
             BINNAME=$(basename $i)
             wget -q https://www.xtideuniversalbios.org/binaries/r$RELEASE/$BINNAME
-            EXPECTED=$(tail -c +64 $BINNAME | md5sum | cut -d ' ' -f 1)
-            ACTUAL=$(tail -c +64 $i | md5sum | cut -d ' ' -f 1)
-            if [ $EXPECTED == $ACTUAL ]; then
-              echo "$BINNAME $ACTUAL $EXPECTED ✅"
+            EXPECTEDHASH=$(tail -c +64 $BINNAME | md5sum | cut -d ' ' -f 1)
+            EXPECTEDSIZE=$(stat -c%s $BINNAME)
+            ACTUALHASH=$(tail -c +64 $i | md5sum | cut -d ' ' -f 1)
+            ACTUALSIZE=$(stat -c%s $i)
+            echo -n "$BINNAME $ACTUALSIZE $EXPECTEDSIZE $ACTUALHASH $EXPECTEDHASH"
+            if [ $EXPECTEDSIZE == $ACTUALSIZE && $EXPECTEDHASH == $ACTUALHASH ]; then
+              echo "✅"
             else
-              echo "$BINNAME $ACTUAL $EXPECTED ❌"
+              echo "❌"
               EXITCODE=1
             fi
           done

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -20,9 +20,9 @@ jobs:
           # registry: gcr.io
           image: xtide-builder:latest
           options: -v ${{ github.workspace }}/src:/src
-          # run: |
-          #   echo "Running Script"
-          #   /work/run-script
+          run: |
+            cd /
+            ./xtide_build.sh
   
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -9,8 +9,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Select 'all' target
         run: sed -i "s/checksum/all/g" ${{ github.workspace }}/resources/options
-      - name: Print build options
-        run: cat ${{ github.workspace }}/resources/options
       - name: Build and push Docker images
         uses: docker/build-push-action@v6.11.0
         with:
@@ -25,6 +23,8 @@ jobs:
           image: xtide-builder:latest
           options: --user 1001:121 -v ${{ github.workspace }}/src:/src
           run: |
+            echo "Building with:"
+            cat /options
             cd /
             ./xtide_build.sh
       - name: List files in the repository

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Select 'all' target
-        run: sed -i "s/checksum/all/g" ${{ runner.workspace }}/resources/options
+        run: sed -i "s/checksum/all/g" ${{ github.workspace }}/resources/options
       # - name: Docker Setup Docker
       #   uses: docker/setup-docker-action@v4.1.0
       - name: Build and push Docker images
@@ -16,19 +16,19 @@ jobs:
         with:
           push: false
           tags: xtide-builder:latest
-      - run: mkdir -p ${{ runner.workspace }}/src
+      - run: mkdir -p ${{ github.workspace }}/src
       - uses: addnab/docker-run-action@v3
         with:
           # username: ${{ secrets.DOCKER_USERNAME }}
           # password: ${{ secrets.DOCKER_PASSWORD }}
           # registry: gcr.io
           image: xtide-builder:latest
-          options: --user 1001:121 -v ${{ runner.workspace }}/src:/src
+          options: --user 1001:121 -v ${{ github.workspace }}/src:/src
           run: |
             cd /
             ./xtide_build.sh
       - name: List files in the repository
         run: |
-          ls -l ${{ runner.workspace }}/src
+          ls -l ${{ github.workspace }}/src
   
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -11,14 +11,14 @@ jobs:
         uses: docker/build-push-action@v6.11.0
         with:
           push: false
-          tags: xtide-builder
+          tags: xtide-builder:latest
       - run: mkdir -p ${{ github.workspace }}/src
       - uses: addnab/docker-run-action@v3
         with:
           # username: ${{ secrets.DOCKER_USERNAME }}
           # password: ${{ secrets.DOCKER_PASSWORD }}
           # registry: gcr.io
-          image: xtide-builder
+          image: xtide-builder:latest
           options: -v ${{ github.workspace }}/src:/src
           # run: |
           #   echo "Running Script"

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -19,7 +19,7 @@ jobs:
           # password: ${{ secrets.DOCKER_PASSWORD }}
           # registry: gcr.io
           image: xtide-builder:latest
-          options: --user $(id -u):$(id -g) -v ${{ github.workspace }}/src:/src
+          options: --user $(id --user):$(id --group) -v ${{ github.workspace }}/src:/src
           run: |
             cd /
             ./xtide_build.sh

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
 jobs:
   Build-Validation:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -9,8 +9,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Select 'all' target
         run: sed -i "s/checksum/all/g" ${{ github.workspace }}/resources/options
-      # - name: Docker Setup Docker
-      #   uses: docker/setup-docker-action@v4.1.0
+      - name: Print build options
+        run: cat ${{ github.workspace }}/resources/options
       - name: Build and push Docker images
         uses: docker/build-push-action@v6.11.0
         with:

--- a/.github/workflows/validation-build.yml
+++ b/.github/workflows/validation-build.yml
@@ -1,4 +1,4 @@
-name: Build Validation
+name: Weekly Build Validation
 run-name: Validation run ${{ github.run_number }} by @${{ github.actor }}
 on: 
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM ubuntu:latest
 
 VOLUME ["/src"]
 
-RUN apt-get update && apt-get -y install make nasm upx-ucl subversion perl
+RUN apt-get update && apt-get -y install make nasm upx-ucl subversion perl ca-certificates
 
 ADD resources/xtide_build.sh /
 ADD resources/options /
-
 
 ENTRYPOINT ["sh","-c","/xtide_build.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookwork-backports
+FROM debian:bookworm-backports
 
 VOLUME ["/src"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 
 VOLUME ["/src"]
 
-RUN apt-get update && apt-get install make nasm upx-ucl subversion perl
+RUN apt-get update && apt-get -y install make nasm upx-ucl subversion perl
 
 ADD resources/xtide_build.sh /
 ADD resources/options /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM debian:bookwork-backports
 
 VOLUME ["/src"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM ubuntu:latest
 
 VOLUME ["/src"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:latest
+FROM debian:latest
 
 VOLUME ["/src"]
 
-RUN apk add --update bash make nasm upx subversion perl
+RUN apt-get update && apt-get install make nasm upx subversion perl
 
 ADD resources/xtide_build.sh /
 ADD resources/options /

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:latest
 
 VOLUME ["/src"]
 
-RUN apt-get update && apt-get install make nasm upx subversion perl
+RUN apt-get update && apt-get install make nasm upx-ucl subversion perl
 
 ADD resources/xtide_build.sh /
 ADD resources/options /

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ What this does:
 * Patches out trailing whitespace in `Revision.inc`, which causes build errors (see BuB's video)
 * Builds the XUB binaries using the `checksum` target, producing ready-to-burn ROM images, tested in PCem.
 * Builds the configurator utility, also tested in PCem.
-* Using a Github Action, verifies that the toolchain produces identical results (except build date in header) to the official binaries
+* Using a Github Action, verifies weekly that the toolchain produces identical results (except build date in header) to the official binaries
 
 On Linux (and macOS probably):
 * Install Docker

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ This is a nice automated way to build XTIDE Universal BIOS ROMs, including creat
 
 What this does:
 * Creates a containerised environment with
-  * Alpine Linux
+  * Debian Linux
+    * This used to be Alpine, but for a reason I cannot fathom, the output from NASM differs. Using the Debian base image, my builds are identical, save for the build date.
+    * See: https://gist.github.com/RetroSwimAU/ae03cb8fbface5f2f58d7757e12ba93f      
   * Bash
   * Subversion
   * GNU Make
@@ -14,6 +16,7 @@ What this does:
 * Patches out trailing whitespace in `Revision.inc`, which causes build errors (see BuB's video)
 * Builds the XUB binaries using the `checksum` target, producing ready-to-burn ROM images, tested in PCem.
 * Builds the configurator utility, also tested in PCem.
+* Using a Github Action, verifies that the toolchain produces identical results (except build date in header) to the official binaries
 
 On Linux (and macOS probably):
 * Install Docker
@@ -46,7 +49,7 @@ Extra features:
   * The example values I provided for a custom build came from Bits Und Bolts' video on the subject: https://www.youtube.com/watch?v=ilEZB5pY0VI
 * If you don't like Docker and wish to build directly in your Linux environment, got you covered.
   * Requires Make, NASM, UPX, Subversion, and Perl.
-    * E.g. `sudo apt install make nasm upx subversion perl`
+    * E.g. `sudo apt install make nasm upx-ucl subversion perl`
   * Clone the repo and run `./uncontained.sh`
 
 Credits:


### PR DESCRIPTION
Added a weekly github action that compares our output with the official images.

As a result, found out that NASM outputs ever-so-slightly different binaries under Alpine as under Debian. The latter matches with the official binaries, which I assume are build on Windows as per their build instructions. Thus, the build environment Docker image is now based on Debian.